### PR TITLE
CLOUDOPS-2725 update python runtime

### DIFF
--- a/deployment.yml
+++ b/deployment.yml
@@ -90,7 +90,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: main.handler
-      Runtime: python3.6
+      Runtime: python3.9
       Timeout: 120
       CodeUri:
         Bucket: !Ref Bucket


### PR DESCRIPTION
We are ending support for Python 3.6 in AWS Lambda. This follows Python 3.6 End-Of-Life (EOL) reached on December 23, 2021 [1].

As described in the Lambda runtime support policy [2], end of support for language runtimes in Lambda happens in two stages. Starting July 18, 2022, Lambda will no longer apply security patches and other updates to the Python 3.6 runtime used by Lambda functions, and functions using Python 3.6 will no longer be eligible for technical support. In addition, you will no longer be able to create new Lambda functions using the Python 3.6 runtime. Starting August 17, 2022, you will no longer be able to update existing functions using the Python 3.6 runtime.