### PR TITLE
remove deprecations in python 3.9

### DIFF
--- a/deployment.yml
+++ b/deployment.yml
@@ -90,7 +90,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: main.handler
-      Runtime: python3.6
+      Runtime: python3.9
       Timeout: 120
       CodeUri:
         Bucket: !Ref Bucket

--- a/lambda/main.py
+++ b/lambda/main.py
@@ -6,7 +6,7 @@ import threading
 import logging
 import re
 
-from botocore.vendored import requests
+import requests
 import boto3
 
 # semaphore limit of 5, picked this number arbitrarily


### PR DESCRIPTION
we are going to update runtime from 3.6 to 3.9, there is deprecation which should be changed according to the blogpost.  https://aws.amazon.com/blogs/developer/removing-the-vendored-version-of-requests-from-botocore/